### PR TITLE
Supabase認証基盤を構築（クライアント作成・Userモデル追加・セッション管理実装）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "shiftbridge-app",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.1.1",
         "@prisma/client": "^6.10.1",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-alert-dialog": "^1.1.14",
@@ -43,7 +44,9 @@
         "next": "14.2.30",
         "react": "^18",
         "react-dom": "^18",
-        "swr": "^2.3.3"
+        "react-hook-form": "^7.59.0",
+        "swr": "^2.3.3",
+        "zod": "^3.25.71"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -229,6 +232,18 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.1.1.tgz",
+      "integrity": "sha512-J/NVING3LMAEvexJkyTLjruSm7aOFx7QX21pzkiJfMoNG0wl5aFEjLTl7ay7IQb9EWY6AkrBy7tHL2Alijpdcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -2044,6 +2059,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-helpers-nextjs": {
@@ -6361,6 +6382,22 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.59.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.59.0.tgz",
+      "integrity": "sha512-kmkek2/8grqarTJExFNjy+RXDIP8yM+QTl3QL6m6Q8b2bih4ltmiXxH7T9n+yXNK477xPh5yZT/6vD8sYGzJTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -8025,6 +8062,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.71",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.71.tgz",
+      "integrity": "sha512-BsBc/NPk7h8WsUWYWYL+BajcJPY8YhjelaWu2NMLuzgraKAz4Lb4/6K11g9jpuDetjMiqhZ6YaexFLOC0Ogi3Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "seed": "ts-node --project tsconfig.prisma.json prisma/seed.ts"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.1.1",
     "@prisma/client": "^6.10.1",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",
@@ -47,7 +48,9 @@
     "next": "14.2.30",
     "react": "^18",
     "react-dom": "^18",
-    "swr": "^2.3.3"
+    "react-hook-form": "^7.59.0",
+    "swr": "^2.3.3",
+    "zod": "^3.25.71"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/_hooks/useUser.ts
+++ b/src/app/_hooks/useUser.ts
@@ -1,0 +1,16 @@
+// src/hooks/useUser.ts
+import useSWR from "swr";
+
+export const useUser = () => {
+  const { data, error, isLoading } = useSWR("/api/session", async (url) => {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error("ユーザー取得失敗");
+    return res.json();
+  });
+
+  return {
+    user: data?.user ?? null,
+    isLoading,
+    isError: error,
+  };
+};

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -2,21 +2,29 @@ import { NextResponse } from "next/server";
 import { signup } from "@/_services/authService";
 
 export async function POST(req: Request) {
+  console.log("✅ サインアップリクエスト受信");
+
   const body = await req.json();
   const { email, password, nickname, roleId } = body;
 
+  console.log("📨 リクエスト内容:", { email, nickname, roleId });
+
   try {
     const user = await signup({ email, password, nickname, roleId });
+
+    console.log("✅ サインアップ成功:", user);
+
     return NextResponse.json({ success: true, user });
   } catch (e: unknown) {
     if (e instanceof Error) {
-      console.error(e);
+      console.error("❌ サインアップエラー:", e.message);
       return NextResponse.json(
         { success: false, error: e.message },
         { status: 500 }
       );
     }
 
+    console.error("❌ 不明なエラーが発生しました");
     return NextResponse.json(
       { success: false, error: "不明なエラーが発生しました。" },
       { status: 500 }

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import { prisma } from "@/_lib/prisma";
 
 export async function POST(req: NextRequest) {
@@ -29,4 +31,21 @@ export async function POST(req: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function GET() {
+  const supabase = createServerComponentClient({ cookies });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ user: null }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+  });
+
+  return NextResponse.json({ user });
 }

--- a/src/app/login/_components/login-form.tsx
+++ b/src/app/login/_components/login-form.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import * as React from "react";
+import { Button } from "@/app/_components/ui/button";
+import { Input } from "@/app/_components/ui/input";
+import { Label } from "@/app/_components/ui/label";
+import { Alert, AlertDescription } from "@/app/_components/ui/alert";
+import { Eye, EyeOff, Loader2, Mail, Lock } from "lucide-react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { createPagesBrowserClient } from "@supabase/auth-helpers-nextjs";
+import { useSession } from "@/app/_hooks/useSession";
+
+export function LoginForm() {
+  const [email, setEmail] = React.useState("");
+  const [password, setPassword] = React.useState("");
+  const [showPassword, setShowPassword] = React.useState(false);
+  const [error, setError] = React.useState("");
+  const [isLoading, setIsLoading] = React.useState(false);
+  const router = useRouter();
+  const { mutateSession } = useSession();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    if (!email || !password) {
+      setError("すべての項目を入力してください");
+      return;
+    }
+
+    setIsLoading(true);
+    const supabase = createPagesBrowserClient();
+    const { error: loginError } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+
+    if (loginError) {
+      setError(loginError.message || "ログインに失敗しました");
+      setIsLoading(false);
+      return;
+    }
+
+    await mutateSession(); // SWRセッションを更新
+    router.push("/");
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {error && (
+        <Alert className="border-red-200 bg-red-50">
+          <AlertDescription className="text-red-700">{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="space-y-4">
+        {/* メールアドレス */}
+        <div>
+          <Label htmlFor="email" className="text-gray-700">
+            メールアドレス
+          </Label>
+          <div className="relative mt-1">
+            <Mail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="your@example.com"
+              className="pl-10 border-emerald-200 focus:border-emerald-400 focus:ring-emerald-400 bg-white rounded-xl shadow-sm"
+              required
+            />
+          </div>
+        </div>
+
+        {/* パスワード */}
+        <div>
+          <Label htmlFor="password" className="text-gray-700">
+            パスワード
+          </Label>
+          <div className="relative mt-1">
+            <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+            <Input
+              id="password"
+              type={showPassword ? "text" : "password"}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="パスワードを入力"
+              className="pl-10 pr-10 border-gray-200 focus:border-primary focus:ring-primary bg-white"
+              required
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowPassword(!showPassword)}
+              className="absolute right-1 top-1/2 -translate-y-1/2 h-8 w-8 p-0 hover:bg-gray-100"
+            >
+              {showPassword ? (
+                <EyeOff className="h-4 w-4" />
+              ) : (
+                <Eye className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <Link
+          href="/auth/reset-password"
+          className="text-sm text-primary hover:text-primary/80 underline"
+        >
+          パスワードを忘れた方
+        </Link>
+      </div>
+
+      <Button
+        type="submit"
+        disabled={isLoading}
+        className="w-full bg-gradient-to-r from-emerald-500 to-green-600 hover:from-emerald-600 hover:to-green-700 text-white shadow-lg rounded-xl transition-all duration-200 btn-modern"
+      >
+        {isLoading ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ログイン中...
+          </>
+        ) : (
+          "ログイン"
+        )}
+      </Button>
+
+      <div className="text-center">
+        <span className="text-sm text-gray-600">
+          アカウントをお持ちでない方は{" "}
+          <Link
+            href="/auth/register"
+            className="text-primary hover:text-primary/80 underline"
+          >
+            新規登録
+          </Link>
+        </span>
+      </div>
+
+      {/* デモログイン情報 */}
+      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+        <h4 className="text-sm font-medium text-blue-900 mb-2">
+          デモ用ログイン情報
+        </h4>
+        <div className="text-xs text-blue-700 space-y-1">
+          <p>
+            <strong>学生:</strong> student@example.com
+          </p>
+          <p>
+            <strong>卒業生:</strong> graduate@example.com
+          </p>
+          <p>
+            <strong>講師:</strong> instructor@example.com
+          </p>
+          <p>
+            <strong>管理者:</strong> admin@example.com
+          </p>
+          <p>
+            <strong>パスワード:</strong> password123
+          </p>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,11 @@
+import { LoginForm } from "./_components/login-form";
+
+export default function LoginPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md space-y-6">
+        <LoginForm />
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,101 +1,35 @@
-import Image from "next/image";
+"use client";
 
-export default function Home() {
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useUser } from "@/app/_hooks/useUser"; // 認証情報取得のカスタムフック（仮）
+
+export default function HomePage() {
+  const { user, isLoading } = useUser();
+  const router = useRouter();
+
+  useEffect(() => {
+    // ログインしていない場合はログイン画面へ
+    if (!isLoading && !user) {
+      router.push("/login");
+    }
+  }, [user, isLoading, router]);
+
+  if (isLoading) {
+    return <p>読み込み中...</p>;
+  }
+
+  if (!user) {
+    return null; // ログイン前は何も表示しない（リダイレクト待ち）
+  }
+
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="https://nextjs.org/icons/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li>Save and see your changes instantly.</li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="https://nextjs.org/icons/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:min-w-44"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="https://nextjs.org/icons/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="https://nextjs.org/icons/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="https://nextjs.org/icons/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+    <main className="p-8">
+      <h1 className="text-2xl font-bold mb-4">
+        ようこそ、{user.nickname} さん！
+      </h1>
+      <p className="text-gray-600">こちらがあなたのホーム画面です。</p>
+      {/* ダッシュボード要素やメニューをここに追加 */}
+    </main>
   );
 }

--- a/src/app/signup/_components/register-form.tsx
+++ b/src/app/signup/_components/register-form.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import * as React from "react";
+import { useForm, SubmitHandler } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Button } from "@/app/_components/ui/button";
 import { Input } from "@/app/_components/ui/input";
 import { Label } from "@/app/_components/ui/label";
@@ -23,21 +26,50 @@ import {
   GraduationCap,
 } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { register } from "@/app/_lib/auth"; // ここは適切なパスに修正
+import { register as registerUser } from "@/app/_lib/auth";
 
 type Role = {
   id: number;
   name: string;
-  label: string; // ← 追加
+  label: string;
 };
 
+// ===========================
+// 🔐 Zod スキーマ定義
+// ===========================
+const registerSchema = z
+  .object({
+    email: z
+      .string()
+      .email({ message: "有効なメールアドレスを入力してください" }),
+    password: z
+      .string()
+      .min(8, { message: "8文字以上で入力してください" })
+      .regex(/[a-z]/, { message: "小文字を含めてください" })
+      .regex(/[A-Z]/, { message: "大文字を含めてください" })
+      .regex(/[0-9]/, { message: "数字を含めてください" }),
+    confirmPassword: z.string(),
+    nickname: z.string().min(1, "ニックネームは必須です"),
+    roleId: z.number(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    path: ["confirmPassword"],
+    message: "パスワードが一致しません",
+  });
+
+type RegisterFormInputs = z.infer<typeof registerSchema>;
+
 export function RegisterForm() {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [nickname, setNickname] = useState("");
-  const [role, setRole] = useState<number | null>(null);
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useForm<RegisterFormInputs>({
+    resolver: zodResolver(registerSchema),
+  });
+
   const [roles, setRoles] = useState<Role[]>([]);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -45,58 +77,25 @@ export function RegisterForm() {
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
 
-  // Role一覧を取得
+  // ロール一覧取得
   useEffect(() => {
     const fetchRoles = async () => {
       const res = await fetch("/api/role");
       const data = await res.json();
       setRoles(data);
       if (data.length > 0) {
-        setRole(data[0].id); // 初期選択
+        setValue("roleId", data[0].id);
       }
     };
     fetchRoles();
-  }, []);
+  }, [setValue]);
 
-  const validatePassword = (password: string) => {
-    if (password.length < 8) {
-      return "パスワードは8文字以上で入力してください";
-    }
-    if (!/(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/.test(password)) {
-      return "パスワードは大文字、小文字、数字を含む必要があります";
-    }
-    return null;
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError("");
+  const onSubmit: SubmitHandler<RegisterFormInputs> = async (data) => {
     setIsLoading(true);
+    setError("");
 
     try {
-      if (!email || !password || !confirmPassword || !nickname || !role) {
-        setError("すべての項目を入力してください");
-        return;
-      }
-
-      const passwordError = validatePassword(password);
-      if (passwordError) {
-        setError(passwordError);
-        return;
-      }
-
-      if (password !== confirmPassword) {
-        setError("パスワードが一致しません");
-        return;
-      }
-
-      const result = await register({
-        email,
-        password,
-        confirmPassword,
-        nickname,
-        roleId: role,
-      });
+      const result = await registerUser(data);
 
       if (result.success) {
         router.push("/");
@@ -105,14 +104,14 @@ export function RegisterForm() {
       }
     } catch (e) {
       console.error(e);
-      setError("エラーが発生しました");
+      setError("サーバーエラーが発生しました");
     } finally {
       setIsLoading(false);
     }
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
       {error && (
         <Alert className="border-red-200 bg-red-50">
           <AlertDescription className="text-red-700">{error}</AlertDescription>
@@ -122,18 +121,16 @@ export function RegisterForm() {
       <div className="space-y-4">
         {/* ニックネーム */}
         <div>
-          <Label htmlFor="name">ニックネーム</Label>
+          <Label htmlFor="nickname">ニックネーム</Label>
           <div className="relative">
             <User className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
-            <Input
-              id="name"
-              type="text"
-              value={nickname}
-              onChange={(e) => setNickname(e.target.value)}
-              required
-              className="pl-10"
-            />
+            <Input id="nickname" {...register("nickname")} className="pl-10" />
           </div>
+          {errors.nickname && (
+            <p className="text-red-500 text-sm mt-1">
+              {errors.nickname.message}
+            </p>
+          )}
         </div>
 
         {/* メール */}
@@ -144,12 +141,13 @@ export function RegisterForm() {
             <Input
               id="email"
               type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
+              {...register("email")}
               className="pl-10"
             />
           </div>
+          {errors.email && (
+            <p className="text-red-500 text-sm mt-1">{errors.email.message}</p>
+          )}
         </div>
 
         {/* ユーザー種別 */}
@@ -158,13 +156,13 @@ export function RegisterForm() {
           <div className="relative">
             <GraduationCap className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 z-10" />
             <Select
-              value={role?.toString()}
-              onValueChange={(value) => setRole(Number(value))}
+              onValueChange={(value) => setValue("roleId", Number(value))}
+              defaultValue={watch("roleId")?.toString()}
             >
               <SelectTrigger className="pl-10 bg-white border border-gray-300">
                 <SelectValue placeholder="ユーザー種別を選択" />
               </SelectTrigger>
-              <SelectContent className="bg-white ">
+              <SelectContent className="bg-white">
                 {roles.map((role) => (
                   <SelectItem key={role.id} value={role.id.toString()}>
                     {role.label}
@@ -183,9 +181,7 @@ export function RegisterForm() {
             <Input
               id="password"
               type={showPassword ? "text" : "password"}
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
+              {...register("password")}
               className="pl-10 pr-10"
             />
             <Button
@@ -202,6 +198,11 @@ export function RegisterForm() {
               )}
             </Button>
           </div>
+          {errors.password && (
+            <p className="text-red-500 text-sm mt-1">
+              {errors.password.message}
+            </p>
+          )}
         </div>
 
         {/* 確認パスワード */}
@@ -212,9 +213,7 @@ export function RegisterForm() {
             <Input
               id="confirmPassword"
               type={showConfirmPassword ? "text" : "password"}
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              required
+              {...register("confirmPassword")}
               className="pl-10 pr-10"
             />
             <Button
@@ -231,6 +230,11 @@ export function RegisterForm() {
               )}
             </Button>
           </div>
+          {errors.confirmPassword && (
+            <p className="text-red-500 text-sm mt-1">
+              {errors.confirmPassword.message}
+            </p>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## 🔐 サインアップ機能の実装

Supabase Auth + Prisma を用いた認証基盤の構築に伴い、サインアップ機能を実装しました。

---

### ✅ 主な変更点

- `POST /api/auth/signup` エンドポイントを新規作成  
  - Supabase Auth に新規ユーザー登録
  - Prisma の `User` テーブルにも登録（supabaseUserId, email, nickname, roleId）

- `src/app/signup/page.tsx`：サインアップ画面を追加

- `RegisterForm.tsx` コンポーネントを作成  
  - `zod` + `react-hook-form` によるバリデーション付き入力フォーム
  - ロールの選択UIを含む（`/api/role` から取得）

---

### 🧪 動作確認項目

- [x] メール、パスワード、ニックネーム、ロールを入力して登録できる
- [x] パスワードと確認用パスワードの一致チェック
- [x] バリデーションエラー表示が適切に動作
- [x] 登録成功後、ホーム画面にリダイレクトされる

---

